### PR TITLE
Fix Windows test portability: line-ending translation, locale encoding, and /tmp assumptions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
-# CSV/TSV test fixtures are byte-exact inputs for byte-level parsers
-# (dataframe-fastcsv reads raw bytes); git must never translate their
-# line endings on checkout, or quoted embedded newlines gain \r on
-# Windows and round-trip tests fail.
+# git should not translate line endings on checkout.
 *.csv -text
 *.tsv -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# CSV/TSV test fixtures are byte-exact inputs for byte-level parsers
+# (dataframe-fastcsv reads raw bytes); git must never translate their
+# line endings on checkout, or quoted embedded newlines gain \r on
+# Windows and round-trip tests fail.
+*.csv -text
+*.tsv -text

--- a/dataframe-fastcsv/tests/Operations/Projection.hs
+++ b/dataframe-fastcsv/tests/Operations/Projection.hs
@@ -10,6 +10,7 @@ module Operations.Projection (tests) where
 
 import qualified Data.Map as M
 import qualified Data.Text as T
+
 -- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
 -- handle's text mode, which on Windows turns \n into \r\n and
 -- corrupts inputs meant for byte-level parsers.

--- a/dataframe-fastcsv/tests/Operations/Projection.hs
+++ b/dataframe-fastcsv/tests/Operations/Projection.hs
@@ -10,10 +10,6 @@ module Operations.Projection (tests) where
 
 import qualified Data.Map as M
 import qualified Data.Text as T
-
--- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
--- handle's text mode, which on Windows turns \n into \r\n and
--- corrupts inputs meant for byte-level parsers.
 import qualified Data.Text.IO.Utf8 as TIO
 
 import Control.Exception (SomeException, evaluate, try)

--- a/dataframe-fastcsv/tests/Operations/Projection.hs
+++ b/dataframe-fastcsv/tests/Operations/Projection.hs
@@ -10,7 +10,10 @@ module Operations.Projection (tests) where
 
 import qualified Data.Map as M
 import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+-- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
+-- handle's text mode, which on Windows turns \n into \r\n and
+-- corrupts inputs meant for byte-level parsers.
+import qualified Data.Text.IO.Utf8 as TIO
 
 import Control.Exception (SomeException, evaluate, try)
 import Data.List (isInfixOf)

--- a/dataframe-fastcsv/tests/Operations/ReadCsv.hs
+++ b/dataframe-fastcsv/tests/Operations/ReadCsv.hs
@@ -37,7 +37,14 @@ import DataFrame.Internal.DataFrame (
  )
 import DataFrame.Schema (Schema (..), SchemaType (..))
 import System.Directory (removeFile)
-import System.IO (IOMode (..), hSetEncoding, hSetNewlineMode, noNewlineTranslation, utf8, withFile)
+import System.IO (
+    IOMode (..),
+    hSetEncoding,
+    hSetNewlineMode,
+    noNewlineTranslation,
+    utf8,
+    withFile,
+ )
 import Test.HUnit
 import Type.Reflection (typeRep)
 

--- a/dataframe-fastcsv/tests/Operations/ReadCsv.hs
+++ b/dataframe-fastcsv/tests/Operations/ReadCsv.hs
@@ -66,10 +66,6 @@ prettyPrintTsv = prettyPrintSeparated '\t'
 
 prettyPrintSeparated :: Char -> FilePath -> DataFrame -> IO ()
 prettyPrintSeparated sep filepath df = withFile filepath WriteMode $ \handle -> do
-    -- Byte-exact UTF-8 output: a default handle uses the OS locale
-    -- encoding (crashes on non-ANSI text under a non-UTF-8 codepage)
-    -- and translates \n to \r\n on Windows, corrupting quoted embedded
-    -- newlines for the byte-level reader.
     hSetEncoding handle utf8
     hSetNewlineMode handle noNewlineTranslation
     let (rows, _) = dataframeDimensions df

--- a/dataframe-fastcsv/tests/Operations/ReadCsv.hs
+++ b/dataframe-fastcsv/tests/Operations/ReadCsv.hs
@@ -37,7 +37,7 @@ import DataFrame.Internal.DataFrame (
  )
 import DataFrame.Schema (Schema (..), SchemaType (..))
 import System.Directory (removeFile)
-import System.IO (IOMode (..), withFile)
+import System.IO (IOMode (..), hSetEncoding, hSetNewlineMode, noNewlineTranslation, utf8, withFile)
 import Test.HUnit
 import Type.Reflection (typeRep)
 
@@ -59,6 +59,12 @@ prettyPrintTsv = prettyPrintSeparated '\t'
 
 prettyPrintSeparated :: Char -> FilePath -> DataFrame -> IO ()
 prettyPrintSeparated sep filepath df = withFile filepath WriteMode $ \handle -> do
+    -- Byte-exact UTF-8 output: a default handle uses the OS locale
+    -- encoding (crashes on non-ANSI text under a non-UTF-8 codepage)
+    -- and translates \n to \r\n on Windows, corrupting quoted embedded
+    -- newlines for the byte-level reader.
+    hSetEncoding handle utf8
+    hSetNewlineMode handle noNewlineTranslation
     let (rows, _) = dataframeDimensions df
     let headers = map fst (L.sortBy (compare `on` snd) (M.toList (columnIndices df)))
     TIO.hPutStrLn

--- a/dataframe-fastcsv/tests/Operations/TypedExtraction.hs
+++ b/dataframe-fastcsv/tests/Operations/TypedExtraction.hs
@@ -12,7 +12,10 @@ import qualified Data.Map as M
 import qualified Data.Proxy as P
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import qualified Data.Text.IO as TIO
+-- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
+-- handle's text mode, which on Windows turns \n into \r\n and
+-- corrupts inputs meant for byte-level parsers.
+import qualified Data.Text.IO.Utf8 as TIO
 
 import Control.Exception (ErrorCall, evaluate, try)
 import Data.Time (Day)

--- a/dataframe-fastcsv/tests/Operations/TypedExtraction.hs
+++ b/dataframe-fastcsv/tests/Operations/TypedExtraction.hs
@@ -12,6 +12,7 @@ import qualified Data.Map as M
 import qualified Data.Proxy as P
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+
 -- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
 -- handle's text mode, which on Windows turns \n into \r\n and
 -- corrupts inputs meant for byte-level parsers.

--- a/dataframe-fastcsv/tests/Properties/Csv.hs
+++ b/dataframe-fastcsv/tests/Properties/Csv.hs
@@ -20,6 +20,7 @@ import qualified Data.List as L
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+
 -- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
 -- handle's text mode, which on Windows turns \n into \r\n and
 -- corrupts inputs meant for byte-level parsers.

--- a/dataframe-fastcsv/tests/Properties/Csv.hs
+++ b/dataframe-fastcsv/tests/Properties/Csv.hs
@@ -20,10 +20,6 @@ import qualified Data.List as L
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-
--- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
--- handle's text mode, which on Windows turns \n into \r\n and
--- corrupts inputs meant for byte-level parsers.
 import qualified Data.Text.IO.Utf8 as TIO
 import qualified Data.Vector as V
 

--- a/dataframe-fastcsv/tests/Properties/Csv.hs
+++ b/dataframe-fastcsv/tests/Properties/Csv.hs
@@ -20,7 +20,10 @@ import qualified Data.List as L
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import qualified Data.Text.IO as TIO
+-- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
+-- handle's text mode, which on Windows turns \n into \r\n and
+-- corrupts inputs meant for byte-level parsers.
+import qualified Data.Text.IO.Utf8 as TIO
 import qualified Data.Vector as V
 
 import DataFrame.IO.CSV (defaultReadOptions)
@@ -130,7 +133,7 @@ the temp file afterwards no matter what.
 -}
 withCsvFile :: String -> T.Text -> (FilePath -> IO a) -> IO a
 withCsvFile label body action = do
-    let path = "/tmp/fastcsv_prop_" <> label <> ".csv"
+    let path = "./tests/data/unstable_csv/fastcsv_prop_" <> label <> ".csv"
     TIO.writeFile path body
     r <- action path
     removeFile path
@@ -209,7 +212,7 @@ prop_unclosed_quote_throws = forAll (listOf1 arbitrary) $ \(cells :: [Cell]) ->
                 T.intercalate "," (map (encodeCell ',' . unCell) cells)
             csv = "v\n" <> plainRow <> ",\"dangling\n"
         result <- run $ do
-            let path = "/tmp/fastcsv_prop_unclosed.csv"
+            let path = "./tests/data/unstable_csv/fastcsv_prop_unclosed.csv"
             TIO.writeFile path csv
             r <- try @CsvParseError (D.fastReadCsv path)
             removeFile path

--- a/tests/Operations/Record.hs
+++ b/tests/Operations/Record.hs
@@ -17,10 +17,6 @@ module Operations.Record where
 import Data.Int (Int64)
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
-
--- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
--- handle's text mode, which on Windows turns \n into \r\n and
--- corrupts inputs meant for byte-level parsers.
 import qualified Data.Text.IO.Utf8 as TIO
 import GHC.Generics (Generic)
 

--- a/tests/Operations/Record.hs
+++ b/tests/Operations/Record.hs
@@ -17,7 +17,11 @@ module Operations.Record where
 import Data.Int (Int64)
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+
+-- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
+-- handle's text mode, which on Windows turns \n into \r\n and
+-- corrupts inputs meant for byte-level parsers.
+import qualified Data.Text.IO.Utf8 as TIO
 import GHC.Generics (Generic)
 
 import qualified DataFrame as D
@@ -25,6 +29,7 @@ import qualified DataFrame.Functions as F
 import qualified DataFrame.Internal.Column as DI
 import DataFrame.Operators
 import qualified DataFrame.Schema as IS
+import System.Directory (getTemporaryDirectory)
 import DataFrame.Typed (Schema)
 import qualified DataFrame.Typed as DT
 
@@ -289,7 +294,8 @@ deriveSchemaReadsCsv = TestCase $ do
                 , "2,eu,20.5"
                 , "3,ap,30.0"
                 ]
-        tmp = "/tmp/dataframe_test_deriveSchema.csv"
+    tmpDir <- getTemporaryDirectory
+    let tmp = tmpDir <> "/dataframe_test_deriveSchema.csv"
     TIO.writeFile tmp csv
     df <- D.readCsvWithSchema orderSchema tmp
     assertEqual

--- a/tests/Operations/Record.hs
+++ b/tests/Operations/Record.hs
@@ -29,9 +29,9 @@ import qualified DataFrame.Functions as F
 import qualified DataFrame.Internal.Column as DI
 import DataFrame.Operators
 import qualified DataFrame.Schema as IS
-import System.Directory (getTemporaryDirectory)
 import DataFrame.Typed (Schema)
 import qualified DataFrame.Typed as DT
+import System.Directory (getTemporaryDirectory)
 
 import Test.HUnit
 

--- a/tests/Operations/WriteCsv.hs
+++ b/tests/Operations/WriteCsv.hs
@@ -4,6 +4,7 @@
 module Operations.WriteCsv where
 
 import qualified Data.Text as T
+
 -- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
 -- handle's text mode, which on Windows turns \n into \r\n and
 -- corrupts inputs meant for byte-level parsers.

--- a/tests/Operations/WriteCsv.hs
+++ b/tests/Operations/WriteCsv.hs
@@ -4,10 +4,14 @@
 module Operations.WriteCsv where
 
 import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+-- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
+-- handle's text mode, which on Windows turns \n into \r\n and
+-- corrupts inputs meant for byte-level parsers.
+import qualified Data.Text.IO.Utf8 as TIO
 import qualified DataFrame as D
 import qualified DataFrame.Internal.Column as DI
 import DataFrame.Internal.DataFrame (DataFrame (..), toCsv, toSeparated)
+import System.Directory (getTemporaryDirectory)
 import Test.HUnit
 
 -- Basic test: Int and Text columns produce correct CSV
@@ -81,7 +85,8 @@ toCsvRoundTrip = TestLabel "toCsv_roundTrip" $ TestCase $ do
                 , ("b", DI.fromList @T.Text ["hello", "world", "test"])
                 ]
     let csvText = toCsv df
-    let tmpPath = "/tmp/dataframe_test_toCsv_roundtrip.csv"
+    tmpDir <- getTemporaryDirectory
+    let tmpPath = tmpDir <> "/dataframe_test_toCsv_roundtrip.csv"
     TIO.writeFile tmpPath csvText
     df' <- D.readCsv tmpPath
     assertEqual

--- a/tests/Operations/WriteCsv.hs
+++ b/tests/Operations/WriteCsv.hs
@@ -4,10 +4,6 @@
 module Operations.WriteCsv where
 
 import qualified Data.Text as T
-
--- UTF-8 byte-mode IO: the plain Data.Text.IO writer honours the
--- handle's text mode, which on Windows turns \n into \r\n and
--- corrupts inputs meant for byte-level parsers.
 import qualified Data.Text.IO.Utf8 as TIO
 import qualified DataFrame as D
 import qualified DataFrame.Internal.Column as DI


### PR DESCRIPTION
## Summary

Running the test suites on Windows currently fails in three independent ways. All three are test-infrastructure issues — **this PR changes no library code** (7 files, +53/−10: six test modules plus a new `.gitattributes`).

After these fixes, the full suites pass on Windows:

- `dataframe:test:tests` — `Cases: 1097  Tried: 1097  Errors: 0  Failures: 0`
- `dataframe-fastcsv:test:tests` — `Cases: 61  Tried: 61  Errors: 0  Failures: 0`

(local run: Windows 11, GHC 9.12; fork CI: windows-latest on GHC 9.6.7 and 9.12.2, links below)

## Root causes and fixes

### 1. No `.gitattributes` → git `core.autocrlf` rewrites CSV fixtures on checkout

GitHub's Windows runners (and many Windows dev machines) default to `core.autocrlf=true`, so every text-looking file — including CSV test fixtures — is checked out with CRLF line endings. Byte-level tests then see `\r` that isn't in the committed fixture. This also silently corrupts fixtures with quoted embedded newlines (e.g. the `quotes_and_newlines` case).

**Fix:** add `.gitattributes` with `*.csv -text` / `*.tsv -text`. `-text` means "no translation of what's in the index", so fixtures that intentionally contain CRLF (e.g. `crlf.csv`) are preserved byte-for-byte as committed.

### 2. Text-mode `Data.Text.IO` in tests → newline translation + locale codepage crashes

A default Haskell handle uses the OS locale encoding and native newline translation. On Windows this breaks roundtrip tests twice over:

- `\n` is written as `\r\n`, corrupting output meant for the byte-level CSV reader (embedded quoted newlines come back different);
- non-ANSI text can't be encoded under a non-UTF-8 codepage at all — e.g. under a GBK locale, `fast_roundtrip_utf8` dies with `commitAndReleaseBuffer: cannot encode character '\676'`.

**Fix:** in test writers, `Data.Text.IO` → `Data.Text.IO.Utf8` (same `writeFile` signature, byte-mode UTF-8, no new dependencies; provided by `text >= 2.1`). For the streaming handle in `prettyPrintSeparated` (fastcsv tests), set the handle explicitly: `hSetEncoding handle utf8` + `hSetNewlineMode handle noNewlineTranslation`.

### 3. Hardcoded `/tmp` paths (3 sites)

`/tmp` doesn't exist on Windows — the path resolves relative to the current drive's root, so the tests only pass by accident if `C:\tmp` happens to exist, and fail with `withFile: does not exist` otherwise.

**Fix:** `System.Directory.getTemporaryDirectory` (sites: `tests/Operations/WriteCsv.hs`, `tests/Operations/Record.hs`; the two property-test paths in `dataframe-fastcsv/tests/Properties/Csv.hs` were moved under `./tests/data/unstable_csv/` alongside the existing pattern there). Non-test `/tmp` uses (`LazyBenchmark` default argument, the huggingface URI predicate) were deliberately left untouched.

## Verification

Upstream has no Windows CI lane, so the CI evidence below comes from my fork, where a temporary fork-only workflow (windows-latest + macos-14 × GHC 9.6.7/9.12.2) was stacked under these same fixes. That exact state is preserved on the [`fix/windows-test-portability-with-ci`](https://github.com/skymanbp/dataframe/tree/fix/windows-test-portability-with-ci) branch; this PR branch is the identical fixes rebased onto current `main` without the workflow commit.

- **Before** (fork CI on unmodified test code): Windows jobs red — https://github.com/skymanbp/dataframe/actions/runs/32095552668
- **After** (same fixes, pre-rebase state):
  - CI (Windows + macOS), all 4 jobs green — https://github.com/skymanbp/dataframe/actions/runs/32160121891
  - Presubmit (hlint + fourmolu) green — https://github.com/skymanbp/dataframe/actions/runs/32160121946
  - CI (ubuntu) green — https://github.com/skymanbp/dataframe/actions/runs/32160121957
- Local full-suite runs on Windows 11 as quoted above.

**Note on Haskell-CI:** that workflow also fails on this branch, but it is red on upstream `main` as well (latest three runs on `main` all conclude `failure`, most recent 2026-08-14), so it appears unrelated to this change.