### PR TITLE
fix: compute skewness as g1

### DIFF
--- a/dataframe-operations/src-internal/DataFrame/Internal/Statistics.hs
+++ b/dataframe-operations/src-internal/DataFrame/Internal/Statistics.hs
@@ -106,7 +106,7 @@ skewnessStep (SkewAcc !n !meanVal !m2 !m3) !x' =
 computeSkewness :: SkewAcc -> Double
 computeSkewness (SkewAcc n _ m2 m3)
     | n < 3 = 0 -- or error "skewness of <3 samples"
-    | otherwise = (sqrt (fromIntegral n - 1) * m3) / sqrt (m2 ^ (3 :: Int))
+    | otherwise = (sqrt (fromIntegral n) * m3) / sqrt (m2 ^ (3 :: Int))
 {-# INLINE computeSkewness #-}
 
 skewness' :: (VU.Unbox a, Real a, Num a) => VU.Vector a -> Double

--- a/tests/Operations/Statistics.hs
+++ b/tests/Operations/Statistics.hs
@@ -56,6 +56,7 @@ skewnessOfSymmetricDataSet =
             0
         )
 
+-- g1, matching scipy.stats.skew
 skewnessOfSimpleDataSet :: Test
 skewnessOfSimpleDataSet =
     TestCase
@@ -63,7 +64,7 @@ skewnessOfSimpleDataSet =
             "Skewness of a simple data set"
             ( abs
                 ( D.skewness' (VU.fromList [25 :: Int, 28, 26, 30, 40, 50, 40])
-                    - 0.566_731_633_676
+                    - 0.612_140_127_240_396_6
                 )
                 < 1e-12
             )


### PR DESCRIPTION
Split out of #214.

skewness used a sqrt(n-1) factor: neither population g1 nor the sample form. Now g1, matching scipy.stats.skew.

Before, on [1, 2, 2, 3, 3, 3, 4, 10]:

```
ghci> D.skewness (F.col @Double "y") df
1.6801920329205566
```

After:

```
ghci> D.skewness (F.col @Double "y") df
1.796200837478836
```

scipy.stats.skew gives 1.7962008374788356. pandas .skew() gives 2.240256043894075, the adjusted Fisher Pearson convention.
